### PR TITLE
Sort issue selection drop down in article editor

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -68,7 +68,7 @@ class ArticleController extends ModuleController
     {
         return [
             'sections' => app()->make(\App\Repositories\SectionRepository::class)->listAll(),
-            'issues' => app()->make(\App\Repositories\IssueRepository::class)->listAll('issue'),
+            'issues' => app()->make(\App\Repositories\IssueRepository::class)->listAll('issue')->sortDesc(),
         ];
     }
 


### PR DESCRIPTION
This makes the latest issue to appear at the top of the drop down menu in article editor, as added articles always tend to belong to the latest issue