### PR TITLE
Partially revert e977dd4a to fix issue section bulking

### DIFF
--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -80,12 +80,11 @@ class Issue extends Model implements Sortable
 
         if ($fillBreak)
         {
-            $rem = count($collection) % $fillBreak;
+            $currently = count($collection) % $fillBreak;
+            $needed = $fillBreak - $currently;
 
-            if ($rem != 0)
+            if ($needed > 0)
             {
-                $needed = $fillBreak - $rem;
-
                 $additionalArticles =
                     app(\App\Repositories\ArticleRepository::class)
                         ->getAdditionalArticles($this, Section::forSlug($section)->first(), $needed);
@@ -108,6 +107,7 @@ class Issue extends Model implements Sortable
         return \App\applyPublishedCriteria($this->article())
                 ->where('section_id', $section->id)
                 ->orderBy('position')
+                ->limit(20)
                 ->get();
     }
 }


### PR DESCRIPTION
In e977dd4a, a change was made to the functionality that found
additional articles for display where a section did not have enough
articles to fill the required space. That change caused any issue which
had zero articles in a section to never return any 'bulked' articles
from previous issues, resulting in a very empty issue page.

This commit partially reverts that commit to restore the correct
functionality. In addition, the cached article lookup that is used to
build this display is now limited in size, as otherwise we would be
caching all articles in the section since the beginning of time
unnecessarily - we will never need more than a small number of articles
(picked at 20 arbitrarily) for this lookup.