### PR TITLE
Add the ability to embed YouTube videos in articles

### DIFF
--- a/config/twill.php
+++ b/config/twill.php
@@ -19,6 +19,11 @@ return [
                 'icon' => 'star-feature',
                 'component' => 'a17-block-review',
             ],
+            'youtube' => [
+                'title' => 'YouTube Video',
+                'icon' => 'video',
+                'component' => 'a17-block-youtube',
+            ],
         ],
         'block_views_path' => 'blocks',
         'block_single_layout' => 'admin/block-preview'

--- a/resources/views/admin/articles/form.blade.php
+++ b/resources/views/admin/articles/form.blade.php
@@ -43,6 +43,6 @@
     ])
 
     @formField('block_editor', [
-        'blocks' => ['text', 'quotation', 'sidebar', 'image', 'review', ]
+        'blocks' => ['text', 'quotation', 'sidebar', 'image', 'review', 'youtube', ]
     ])
 @stop

--- a/resources/views/admin/blocks/youtube.blade.php
+++ b/resources/views/admin/blocks/youtube.blade.php
@@ -1,0 +1,4 @@
+@formField('input', [
+'name' => 'link',
+'label' => 'YouTube Video Link'
+])

--- a/resources/views/blocks/youtube.blade.php
+++ b/resources/views/blocks/youtube.blade.php
@@ -1,0 +1,6 @@
+<?php
+    preg_match('/((?<=watch\?v=)|(?<=youtu.be\/))[a-zA-Z_0-9]+\/?/', $block->input('link'), $matches)
+?>
+<section class="youtube">
+    <iframe width="560" height="315" src={{ "https://www.youtube-nocookie.com/embed/" . $matches[0] }} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</section>


### PR DESCRIPTION
A new editor block YouTube Video is added. Users can paste in video URLs in the form of "https://youtube.com/watch?v=XXXXXXX" or "https://youtu.be/XXXXXXXX" to embed a video in their article.